### PR TITLE
Update Serilog.AspNetCore to 4.1.0 to fix build error

### DIFF
--- a/daemonapp.csproj
+++ b/daemonapp.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="JoySoftware.NetDaemon.App" Version="21.13.0-beta" />
     <PackageReference Include="JoySoftware.NetDaemon.DaemonRunner" Version="21.13.0-beta" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Without upgrading this package, the template blows up with the following error:

```sh
/home/ani/code/anaisbetts/personal-docker/home.anais.dev/netdaemon/daemonapp.csproj : error NU1605: Detected package downgrade: Serilog.AspNetCore from 4.1.0 to 3.4.0. Reference the package directly from the project to select a different version. 
/home/ani/code/anaisbetts/personal-docker/home.anais.dev/netdaemon/daemonapp.csproj : error NU1605:  daemonapp -> JoySoftware.NetDaemon.DaemonRunner 21.13.0-beta -> Serilog.AspNetCore (>= 4.1.0) 
/home/ani/code/anaisbetts/personal-docker/home.anais.dev/netdaemon/daemonapp.csproj : error NU1605:  daemonapp -> Serilog.AspNetCore (>= 3.4.0)

The build failed. Fix the build errors and run again.
```