### PR TITLE
Make the focus attribute work in Visual Studio

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -3,6 +3,9 @@
     "daemonapp": {
       "commandName": "Project",
       "workingDirectory": "$(SolutionDir)"
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }


### PR DESCRIPTION
This sets the environment so that the Focus Attribute works out of the box. 