### PR TITLE
Ensure template app starts up in execution folder

### DIFF
--- a/program.cs
+++ b/program.cs
@@ -3,6 +3,8 @@ using NetDaemon;
 
 try
 {
+    Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+    
     await Host.CreateDefaultBuilder(args)
         .UseDefaultNetDaemonLogging()
         .UseNetDaemon()


### PR DESCRIPTION
This ensures that any subsequent requests to the filesystem (for example a logger configuration that writes logs to the filesystem) defaults to the application's startup folder.

I discovered this (surprise!) when setting up file-based logging but it's generally good practise anyway, so that the default folder is the execution location. I've tried this with my local setup and deployed to my own HA environment and all works as expected
However I guess it *might* be deemed a breaking change if anyone's forks are already changing up the folder structure.